### PR TITLE
Replace tests with autogenerated tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -1,7 +1,11 @@
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "cmrel" tool which generated it
+# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode current
 periodics:
   - agent: kubernetes
     annotations:
       description: Runs unit and integration tests and verification scripts
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
     decorate: true
@@ -13,6 +17,7 @@ periodics:
     labels:
       preset-make-volumes: "true"
       preset-service-account: "true"
+    max_concurrency: 8
     name: ci-cert-manager-make-test
     spec:
       containers:
@@ -26,7 +31,7 @@ periodics:
           image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
-              cpu: 2
+              cpu: "2"
               memory: 4Gi
       dnsConfig:
         options:
@@ -51,7 +56,9 @@ periodics:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-e2e-v1-20
     spec:
       containers:
@@ -95,7 +102,9 @@ periodics:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-e2e-v1-21
     spec:
       containers:
@@ -139,7 +148,9 @@ periodics:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-e2e-v1-22
     spec:
       containers:
@@ -183,7 +194,9 @@ periodics:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-e2e-v1-23
     spec:
       containers:
@@ -227,7 +240,9 @@ periodics:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-e2e-v1-24
     spec:
       containers:
@@ -252,11 +267,9 @@ periodics:
         options:
           - name: ndots
             value: "1"
-  # This test runs Venafi (VaaS and TPP) tests once every 12hrs.
-  # This is the only CI test job that runs those.
   - agent: kubernetes
     annotations:
-      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
+      description: Runs Venafi (VaaS and TPP) e2e tests
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -271,10 +284,12 @@ periodics:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-    name: ci-cert-manager-venafi
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-24-issuers-venafi
     spec:
       containers:
         - args:
@@ -300,12 +315,11 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs cert-manager upgrade test every 8 hours
+      description: Runs cert-manager upgrade from latest published release
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
     decorate: true
-    # extra refs specify what repo should be cloned
     extra_refs:
       - base_ref: master
         org: cert-manager
@@ -316,7 +330,8 @@ periodics:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-upgrade
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-24-upgrade
     spec:
       containers:
         - args:
@@ -339,59 +354,9 @@ periodics:
         options:
           - name: ndots
             value: "1"
-  # TODO: find a permanent home for the AWS periodics and reinstate this job
-  # - name: aws-tests
-  #   interval: 48h
-  #   agent: kubernetes
-  #   decorate: true
-  #   extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
-  #     - org: cert-manager
-  #       repo: test-infra
-  #       base_ref: main
-  #     - org: cert-manager
-  #       repo: cert-manager
-  #       base_ref: master
-  #   annotations:
-  #     testgrid-create-test-group: 'true'
-  #     testgrid-dashboards: jetstack-cert-manager-master
-  #     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-  #     description: Runs the end-to-end test suite against a EKS cluster
-  #   labels:
-  #     preset-service-account: "true"
-  #     preset-dind-enabled: "true"
-  #     preset-bazel-remote-cache-enabled: "true"
-  #     preset-bazel-scratch-dir: "true"
-  #     preset-aws-credentials: "true"
-  #     preset-ginkgo-focus-http01-ingress: "true"
-  #   spec:
-  #     containers:
-  #     - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
-  #       args:
-  #       - bash
-  #       - -c
-  #       - |
-  #         set -euo && \
-  #         ls && \
-  #         pwd && \
-  #         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-  #         terraform init && \
-  #         trap 'terraform destroy -auto-approve' ERR && \
-  #         terraform apply -auto-approve && \
-  #         ls && \
-  #         pwd && \
-  #         cd /home && \
-  #         ls && \
-  #         cd /home/prow/go/src/github.com/cert-manager/cert-manager && \
-  #         ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-  #         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-  #         terraform destroy -auto-approve;
-  #       resources:
-  #         requests:
-  #           cpu: 3500m
-  #           memory: 12Gi
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -406,10 +371,12 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-e2e-feature-gates-disabled-v1-20
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-20-feature-gates-disabled
     spec:
       containers:
         - args:
@@ -435,7 +402,7 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -450,10 +417,12 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-e2e-feature-gates-disabled-v1-21
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-21-feature-gates-disabled
     spec:
       containers:
         - args:
@@ -479,7 +448,7 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -494,10 +463,12 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-e2e-feature-gates-disabled-v1-22
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-22-feature-gates-disabled
     spec:
       containers:
         - args:
@@ -523,7 +494,7 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -538,10 +509,12 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-e2e-feature-gates-disabled-v1-23
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-23-feature-gates-disabled
     spec:
       containers:
         - args:
@@ -567,7 +540,7 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-master
@@ -582,10 +555,12 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-e2e-feature-gates-disabled-v1-24
+    max_concurrency: 4
+    name: ci-cert-manager-e2e-v1-24-feature-gates-disabled
     spec:
       containers:
         - args:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -1,19 +1,18 @@
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "cmrel" tool which generated it
+# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode current
 presubmits:
   cert-manager/cert-manager:
-    # Why do we have only have presubmits on "master" but not on the
-    # to-be-released branch, e.g. "release-1.9"? Because we don't need to be
-    # testing e.g. release-1.9 before we have made the first alpha release, e.g.,
-    # "1.9.0-alpha.0". See Step 13.3 in
-    # https://cert-manager.io/docs/contributing/release-process/
     - agent: kubernetes
       always_run: true
       annotations:
+        description: Runs unit and integration tests and verification scripts
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
         - master
       decorate: true
-      description: Runs unit and integration tests and verification scripts
       labels:
         preset-make-volumes: "true"
         preset-service-account: "true"
@@ -32,20 +31,17 @@ presubmits:
             image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
             resources:
               requests:
-                cpu: 2
+                cpu: "2"
                 memory: 4Gi
         dnsConfig:
           options:
             - name: ndots
               value: "1"
-    # Helm chart verification currently requires Docker.
-    # We maintain a standalone presubmit for running this.
-    # See https://github.com/helm/chart-testing/issues/53
-    # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
     - agent: kubernetes
       always_run: true
       annotations:
         description: Verifies the Helm chart passes linting checks
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -57,6 +53,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 8
       name: pull-cert-manager-chart
+      optional: false
       spec:
         containers:
           - args:
@@ -67,9 +64,8 @@ presubmits:
             image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: 1Gi
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
         dnsConfig:
@@ -80,6 +76,7 @@ presubmits:
       always_run: false
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -124,6 +121,7 @@ presubmits:
       always_run: false
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -168,6 +166,7 @@ presubmits:
       always_run: false
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -212,6 +211,7 @@ presubmits:
       always_run: false
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -252,11 +252,11 @@ presubmits:
           options:
             - name: ndots
               value: "1"
-    # This is the default e2e test for all PRs against cert-manager master branch
     - agent: kubernetes
       always_run: true
       annotations:
-        description: Runs 'make e2e-ci K8S_VERSION=1.24'
+        description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
@@ -297,28 +297,23 @@ presubmits:
           options:
             - name: ndots
               value: "1"
-    # Verifies upgrade from the latest published release with both Helm chart and static manifests.
-    # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
-    - # This job will run on Kubernetes cluster.
-      agent: kubernetes
-      # Run always
+    - agent: kubernetes
       always_run: true
       annotations:
         description: Runs cert-manager upgrade from latest published release
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       branches:
         - master
-      # Pod utilities will be set up.
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
         preset-dind-enabled: "true"
         preset-make-volumes: "true"
         preset-service-account: "true"
-      # No more than 4 instances of this job at the same time.
       max_concurrency: 4
-      name: pull-cert-manager-upgrade
+      name: pull-cert-manager-e2e-v1-24-upgrade
       optional: false
       spec:
         containers:
@@ -342,20 +337,15 @@ presubmits:
           options:
             - name: ndots
               value: "1"
-    # An E2E test job to allow us to manually trigger the Venafi  TPP E2E tests
-    # with the following GitHub comment:
-    #
-    #  /test pull-cert-manager-issuers-venafi-tpp
-    #
-    # See https://github.com/cert-manager/cert-manager/issues/3555
-    #
     - agent: kubernetes
       always_run: false
       annotations:
         description: Runs the E2E tests with 'Venafi TPP' in name
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      branches: []
+      branches:
+        - master
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
@@ -366,7 +356,7 @@ presubmits:
         preset-service-account: "true"
         preset-venafi-tpp-credentials: "true"
       max_concurrency: 4
-      name: pull-cert-manager-issuers-venafi-tpp
+      name: pull-cert-manager-e2e-v1-24-issuers-venafi-tpp
       optional: true
       spec:
         containers:
@@ -391,20 +381,15 @@ presubmits:
           options:
             - name: ndots
               value: "1"
-    # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
-    # with the following GitHub comment:
-    #
-    #  /test pull-cert-manager-issuers-venafi-cloud
-    #
-    # The regular presubmit jobs do not run Venafi e2e tests.
-    #
     - agent: kubernetes
       always_run: false
       annotations:
         description: Runs the E2E tests with 'Venafi Cloud' in name
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      branches: []
+      branches:
+        - master
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
@@ -415,7 +400,7 @@ presubmits:
         preset-service-account: "true"
         preset-venafi-cloud-credentials: "true"
       max_concurrency: 4
-      name: pull-cert-manager-e2e-issuers-venafi-cloud
+      name: pull-cert-manager-e2e-v1-24-issuers-venafi-cloud
       optional: true
       spec:
         containers:
@@ -425,7 +410,7 @@ presubmits:
               - -j
               - vendor-go
               - e2e-ci
-              - K8S_VERSION=1.23
+              - K8S_VERSION=1.24
             image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
             resources:
               requests:
@@ -444,9 +429,11 @@ presubmits:
       always_run: false
       annotations:
         description: Runs the E2E tests with all feature gates disabled
+        testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
         testgrid-create-test-group: "true"
         testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      branches: []
+      branches:
+        - master
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -458,7 +445,7 @@ presubmits:
         preset-retry-flakey-tests: "true"
         preset-service-account: "true"
       max_concurrency: 4
-      name: pull-cert-manager-e2e-feature-gates-disabled
+      name: pull-cert-manager-e2e-v1-24-feature-gates-disabled
       optional: true
       spec:
         containers:
@@ -468,7 +455,7 @@ presubmits:
               - -j
               - vendor-go
               - e2e-ci
-              - K8S_VERSION=1.23
+              - K8S_VERSION=1.24
             image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
             resources:
               requests:

--- a/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -1,15 +1,11 @@
-# We don't need periodically testing the release-next breanch (e.g., the
-# "release-1.9" branch) until we release the first alpha (e.g.,
-# "1.9.0-alpha.0"). Since we can't "deactivate" the release-next periodics jobs
-# until we have an alpha (there is no "skip" field on the ProwJob object), we
-# set an arbitrarily large interval of 6 month. See Step 13.3 in
-# https://cert-manager.io/docs/contributing/release-process/
-
-# Since we're in an alpha phase now, we'll enable these tests
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "cmrel" tool which generated it
+# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode next
 periodics:
   - agent: kubernetes
     annotations:
       description: Runs unit and integration tests and verification scripts
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-next
     decorate: true
@@ -21,6 +17,7 @@ periodics:
     labels:
       preset-make-volumes: "true"
       preset-service-account: "true"
+    max_concurrency: 8
     name: ci-cert-manager-next-make-test
     spec:
       containers:
@@ -34,7 +31,7 @@ periodics:
           image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
-              cpu: 2
+              cpu: "2"
               memory: 4Gi
       dnsConfig:
         options:
@@ -59,7 +56,9 @@ periodics:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-next-e2e-v1-20
     spec:
       containers:
@@ -103,7 +102,9 @@ periodics:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-next-e2e-v1-21
     spec:
       containers:
@@ -144,9 +145,12 @@ periodics:
       preset-cloudflare-credentials: "true"
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-next-e2e-v1-22
     spec:
       containers:
@@ -187,9 +191,12 @@ periodics:
       preset-cloudflare-credentials: "true"
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-next-e2e-v1-23
     spec:
       containers:
@@ -230,9 +237,12 @@ periodics:
       preset-cloudflare-credentials: "true"
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-next-e2e-v1-24
     spec:
       containers:
@@ -259,13 +269,13 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
+      description: Runs Venafi (VaaS and TPP) e2e tests
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-next
     decorate: true
     extra_refs:
-      - base_ref: master
+      - base_ref: release-1.9
         org: cert-manager
         repo: cert-manager
     interval: 12h
@@ -274,10 +284,12 @@ periodics:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-    name: ci-cert-manager-next-venafi
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-24-issuers-venafi
     spec:
       containers:
         - args:
@@ -303,12 +315,11 @@ periodics:
             value: "1"
   - agent: kubernetes
     annotations:
-      description: Runs cert-manager upgrade test every 8 hours
+      description: Runs cert-manager upgrade from latest published release
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-master
+      testgrid-dashboards: jetstack-cert-manager-next
     decorate: true
-    # extra refs specify what repo should be cloned
     extra_refs:
       - base_ref: release-1.9
         org: cert-manager
@@ -319,14 +330,246 @@ periodics:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-next-upgrade
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-24-upgrade
     spec:
       containers:
         - args:
             - runner
             - make
-            - cluster
-            - verify_upgrade
+            - K8S_VERSION=1.24
+            - vendor-go
+            - test-upgrade
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-20-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-21-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-22-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-23-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-next-e2e-v1-24-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
           image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:

--- a/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-presubmits.yaml
@@ -1,45 +1,14 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
 # Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode previous
+# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode next
 presubmits:
   cert-manager/cert-manager:
     - agent: kubernetes
       always_run: true
       annotations:
-        description: Runs (mostly bazel) tests in the ./hack directory
-      branches:
-        - release-1.8
-      decorate: true
-      labels:
-        preset-bazel-remote-cache-enabled: "true"
-        preset-bazel-scratch-dir: "true"
-        preset-service-account: "true"
-      max_concurrency: 8
-      name: pull-cert-manager-bazel-hack
-      optional: false
-      spec:
-        containers:
-          - args:
-              - runner
-              - bazel
-              - test
-              - --jobs=1
-              - //hack/...
-            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-            resources:
-              requests:
-                cpu: "1"
-                memory: 2Gi
-        dnsConfig:
-          options:
-            - name: ndots
-              value: "1"
-    - agent: kubernetes
-      always_run: true
-      annotations:
         description: Runs unit and integration tests and verification scripts
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-make-volumes: "true"
@@ -70,7 +39,7 @@ presubmits:
       annotations:
         description: Verifies the Helm chart passes linting checks
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-dind-enabled: "true"
@@ -100,51 +69,9 @@ presubmits:
     - agent: kubernetes
       always_run: false
       annotations:
-        description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
-      branches:
-        - release-1.8
-      decorate: true
-      labels:
-        preset-cloudflare-credentials: "true"
-        preset-default-e2e-volumes: "true"
-        preset-dind-enabled: "true"
-        preset-enable-all-feature-gates-disable-ssa: "true"
-        preset-ginkgo-skip-default: "true"
-        preset-make-volumes: "true"
-        preset-retry-flakey-tests: "true"
-        preset-service-account: "true"
-      max_concurrency: 4
-      name: pull-cert-manager-e2e-v1-19
-      optional: true
-      spec:
-        containers:
-          - args:
-              - runner
-              - make
-              - -j
-              - vendor-go
-              - e2e-ci
-              - K8S_VERSION=1.19
-            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-            resources:
-              requests:
-                cpu: 3500m
-                memory: 12Gi
-            securityContext:
-              capabilities:
-                add:
-                  - SYS_ADMIN
-              privileged: true
-        dnsConfig:
-          options:
-            - name: ndots
-              value: "1"
-    - agent: kubernetes
-      always_run: false
-      annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -186,7 +113,7 @@ presubmits:
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -228,7 +155,7 @@ presubmits:
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -270,7 +197,7 @@ presubmits:
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -312,7 +239,7 @@ presubmits:
       annotations:
         description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"
@@ -354,7 +281,7 @@ presubmits:
       annotations:
         description: Runs cert-manager upgrade from latest published release
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
@@ -391,7 +318,7 @@ presubmits:
       annotations:
         description: Runs the E2E tests with 'Venafi TPP' in name
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
@@ -432,7 +359,7 @@ presubmits:
       annotations:
         description: Runs the E2E tests with 'Venafi Cloud' in name
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-default-e2e-volumes: "true"
@@ -473,7 +400,7 @@ presubmits:
       annotations:
         description: Runs the E2E tests with all feature gates disabled
       branches:
-        - release-1.8
+        - release-1.9
       decorate: true
       labels:
         preset-cloudflare-credentials: "true"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -1,43 +1,10 @@
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "cmrel" tool which generated it
+# Generated with: /home/ashley/workspace/cert-manager-release/bin/cmrel generate-tests --mode previous
 periodics:
   - agent: kubernetes
     annotations:
-      description: Runs 'bazel test --jobs=1 //...'
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8 # still required on 1.8 because some tests were only present in bazel
-        org: cert-manager
-        repo: cert-manager
-    interval: 2h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-bazel
-    spec:
-      containers:
-        - args:
-            - runner
-            - bazel
-            - test
-            - --jobs=1
-            - //hack/...
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 1
-              memory: 2Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-  # Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
-  # a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
+      description: Runs (mostly bazel) tests in the ./hack directory
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-previous
@@ -50,49 +17,61 @@ periodics:
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-alpha-enable-output-formats-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-v1-18
+    max_concurrency: 8
+    name: ci-cert-manager-previous-bazel-hack
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.18"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - bazel
+            - test
+            - --jobs=1
+            - //hack/...
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
+              cpu: "1"
+              memory: 2Gi
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs unit and integration tests and verification scripts
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: ci-cert-manager-previous-make-test
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - ci-presubmit
+            - test-ci
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
@@ -106,23 +85,26 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-19
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.19"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.19
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -132,25 +114,10 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
@@ -164,23 +131,26 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-20
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.20"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -190,25 +160,10 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
@@ -222,23 +177,26 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-21
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.21"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -248,25 +206,10 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
@@ -280,23 +223,26 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-22
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.22"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -306,25 +252,10 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
@@ -338,23 +269,26 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-23
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.23"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -364,27 +298,10 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  # This job uses make to invoke end-to-end tests as support for running jobs against 1.24
-  # was only backported into the make based e2e infra in the release-1.8 branch.
   - agent: kubernetes
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
@@ -398,15 +315,15 @@ periodics:
         repo: cert-manager
     interval: 2h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
+    max_concurrency: 4
     name: ci-cert-manager-previous-e2e-v1-24
     spec:
       containers:
@@ -431,11 +348,9 @@ periodics:
         options:
           - name: ndots
             value: "1"
-  # This test runs Venafi (VaaS and TPP) tests once every 12hrs.
-  # This is the only CI test job that runs those.
   - agent: kubernetes
     annotations:
-      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
+      description: Runs Venafi (VaaS and TPP) e2e tests
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-previous
@@ -446,23 +361,26 @@ periodics:
         repo: cert-manager
     interval: 12h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-    name: ci-cert-manager-previous-venafi
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-24-issuers-venafi
     spec:
       containers:
         - args:
             - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.23"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -472,55 +390,38 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
-      description: Runs cert-manager upgrade test every 8 hours
+      description: Runs cert-manager upgrade from latest published release
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-previous
     decorate: true
-    # extra refs specify what repo should be cloned
     extra_refs:
       - base_ref: release-1.8
         org: cert-manager
         repo: cert-manager
     interval: 8h
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
+      preset-make-volumes: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-previous-upgrade
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-24-upgrade
     spec:
       containers:
         - args:
             - runner
             - make
-            - cluster
-            - verify_upgrade
-          env:
-            - name: K8S_VERSION
-              value: "1.23"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+            - K8S_VERSION=1.24
+            - vendor-go
+            - test-upgrade
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
           resources:
             requests:
               cpu: 3500m
@@ -530,378 +431,13 @@ periodics:
               add:
                 - SYS_ADMIN
             privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
       dnsConfig:
         options:
           - name: ndots
             value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
   - agent: kubernetes
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-18
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.18"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-19
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.19"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-20
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.20"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-21
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.21"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-22
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.22"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-test-group: "true"
-      testgrid-dashboards: jetstack-cert-manager-previous
-    decorate: true
-    extra_refs:
-      - base_ref: release-1.8
-        org: cert-manager
-        repo: cert-manager
-    interval: 24h
-    labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-retry-flakey-tests: "true"
-      preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-23
-    spec:
-      containers:
-        - args:
-            - runner
-            - devel/ci-run-e2e.sh
-          env:
-            - name: K8S_VERSION
-              value: "1.23"
-          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 12Gi
-          securityContext:
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-  # This job uses make to invoke end-to-end tests as support for running jobs against 1.24
-  # was only backported into the make based e2e infra in the release-1.8 branch.
-  - agent: kubernetes
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+      description: Runs the E2E tests with all feature gates disabled
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-test-group: "true"
       testgrid-dashboards: jetstack-cert-manager-previous
@@ -916,10 +452,242 @@ periodics:
       preset-default-e2e-volumes: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
       preset-retry-flakey-tests: "true"
       preset-service-account: "true"
-    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-24
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-19-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.19
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-20-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-21-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-22-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-23-feature-gates-disabled
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    max_concurrency: 4
+    name: ci-cert-manager-previous-e2e-v1-24-feature-gates-disabled
     spec:
       containers:
         - args:


### PR DESCRIPTION
This uses the new `cmrel generate-tests` command to generate tests instead of them being manually specified by hand.

Note that this uses the `sortedtests` branch as a base - in that branch I've sorted all the YAML tests, which makes human comparisons (as intended by this PR) much easier.

Note also that the [generation commands](https://github.com/cert-manager/cert-manager/issues/4712) will produce a single file for each of `next`, `previous` and `current`, but the files have been manually split herein order to make it easier to compare the generated tests to the manually specified tests.

We'll combine the tests into those single files after this the idea here is given the green light.